### PR TITLE
feat: spatial routing, sub-skill restructure, DABs fixes

### DIFF
--- a/.agents/build-business/generate-data/assets/canonical_generator_pattern.md
+++ b/.agents/build-business/generate-data/assets/canonical_generator_pattern.md
@@ -27,7 +27,7 @@ def generate_canonical(
     demand,            # DemandConfig object
     body_generators,   # dict: {"event_type_name": fn(context, seed_data) -> dict}
     context_factory,   # fn(seed_data) -> context dict for one entity lifecycle
-    days=90,
+    days=40,
     epoch=datetime(2024, 1, 1),
     random_seed=42,
 ):
@@ -126,6 +126,91 @@ def sample_delay(delay_config, rng):
     else:
         raise ValueError(f"Unknown distribution: {dist}")
 ```
+
+## Spatial Routing in the Generator
+
+When tracking events have a `route` config, the context factory computes the route once per entity lifecycle, and tracking body generators index into it.
+
+### Route Computation in Context Factory
+
+```python
+from routing import RoadGraph, great_circle_route
+
+# Load graph ONCE at generator startup (not per-entity)
+# For multiple service areas, load one graph per area
+road_graph = RoadGraph.load(center=(37.77, -122.42), radius_km=6.4, network_type="drive")
+
+def context_factory_with_routing(seed_data, rng, route_config):
+    """Extended context factory that computes routes for spatial tracking."""
+    # ... pick seed data as usual ...
+
+    # Generate destination if needed
+    if destination_mode == "generated_in_area":
+        # For road businesses, use the graph's random_node — guaranteed routable
+        dest = road_graph.generate_location_in_area(rng, with_address=True)
+        dest_lat, dest_lon = dest["lat"], dest["lon"]
+        dest_address = dest["address"]
+
+    # Compute route based on mode
+    waypoints = [(origin_lat, origin_lon), (dest_lat, dest_lon)]
+    # Multi-stop: just add more waypoints to the list
+
+    if route_config["mode"] == "road":
+        route_points, distance_m = road_graph.route_multi(waypoints)
+    elif route_config["mode"] == "air":
+        route_points = great_circle_route(waypoints, points_per_segment=100)
+        distance_m = None  # use great_circle_distance_km if needed
+
+    context["route_points"] = route_points
+    context["route_json"] = [[p[0], p[1]] for p in route_points]
+    # ... return context ...
+```
+
+Route results are cached automatically by `osrm_route` — identical waypoint pairs return the cached route without another API call.
+
+### Tracking Body Generators with Routes
+
+```python
+from routing import route_position_at, route_heading_at, climb_cruise_descend, constant_with_jitter
+
+# Road-based (ghost kitchen)
+"driver_ping": lambda ctx, seed, rng, progress=0: {
+    "ping_lat": route_position_at(ctx["route_points"], progress)[0],
+    "ping_lon": route_position_at(ctx["route_points"], progress)[1],
+    "ping_progress": progress * 100,
+},
+
+# Air-based (airline) with derived field profiles
+"flight_position": lambda ctx, seed, rng, progress=0: {
+    "ping_lat": route_position_at(ctx["route_points"], progress)[0],
+    "ping_lon": route_position_at(ctx["route_points"], progress)[1],
+    "ping_progress": progress * 100,
+    "ping_altitude_ft": climb_cruise_descend(progress, max_value=35000),
+    "ping_speed_knots": constant_with_jitter(450, 20, rng),
+    "ping_heading": route_heading_at(ctx["route_points"], progress),
+},
+```
+
+### Graph Loading Strategy
+
+Load ONE graph per service area at generator startup. The graph stays in memory for the entire run.
+
+```python
+# Multiple service areas = multiple graphs
+graphs = {}
+for loc in seed_data["locations"].itertuples():
+    graphs[loc.location_id] = RoadGraph.load(
+        center=(loc.lat, loc.lon),
+        radius_km=6.4,
+        network_type="drive",  # or "walk" for pedestrian businesses
+    )
+```
+
+Route caching is built into `RoadGraph` — same origin→destination pair returns the cached result. For businesses with fixed origins, there are only `N_origins × N_destinations` unique routes.
+
+For air routes, no graph needed — `great_circle_route` is pure math.
+
+---
 
 ## The Business-Specific Parts
 

--- a/.agents/build-business/generate-data/assets/data-generation.md
+++ b/.agents/build-business/generate-data/assets/data-generation.md
@@ -76,7 +76,7 @@ The event stream is the heartbeat of the demo. Events flow through time, referen
 
 **Why not generate events live?** Live generation is fragile (job crashes = data stops), slow to backfill, and hard to reproduce. Instead:
 
-1. **Offline generation**: Pre-generate a canonical dataset covering N days (e.g., 90 days)
+1. **Offline generation**: Pre-generate a canonical dataset covering N days (e.g., 40 days)
 2. **Replay engine**: A scheduled job replays events at configurable speed with checkpoint-based resumption
 
 This gives you: instant historical backfill, reproducible data, configurable speed, and crash resilience.
@@ -191,6 +191,142 @@ started_to_finished: {median: 10, cv: 0.3}
 ready_to_pickup: {median: 6, cv: 0.33}
 ```
 
+### Spatial Tracking & Routing
+
+Many businesses involve entities that move through physical space. The skill supports generating realistic GPS tracking events with real road routes or great-circle (air) paths.
+
+**Code:** `assets/routing.py` — reference implementation for routing, geocoding, and derived field profiles. Inline into generated code, don't import.
+
+#### The Routing Primitive
+
+Given an ordered list of waypoints (lat/lon pairs), produce a route and tracking events along it. That's it. Everything else — where the waypoints come from, whether there's a radius constraint, what extra fields to track — is business-level.
+
+Two modes:
+- **`road`**: Real road routes via OSM graph + Dijkstra. Downloads the road network once per service area (~30-60s), then all routes are local and fast (milliseconds each). Dependencies: `osmnx`, `networkx` (`%pip install osmnx networkx`).
+- **`air`**: Great-circle interpolation. Suitable for flights, drones, anything not on roads. Zero dependencies.
+
+Multi-stop is native — chain shortest paths between consecutive waypoints on the same graph.
+
+Fallback for `road` when osmnx isn't available: OSRM public API (one HTTP call per route, slower but zero install).
+
+#### Address Resolution
+
+| Service | What it does | When to use |
+|---|---|---|
+| **Nominatim forward geocode** | Address string → (lat, lon) | Seed data has addresses, needs coords |
+| **Nominatim reverse geocode** | (lat, lon) → address string | Generated coords need a display address |
+| **RoadGraph.random_node()** | Random point on a real road | Best way to generate locations — guaranteed routable, no snapping needed |
+
+Rate limits: Nominatim is 1 req/sec, fine for seed data (tens/hundreds of rows). The graph-based approach has no rate limits — it's all local after the initial download.
+
+For road-based businesses, prefer `RoadGraph.random_node()` over random-point-in-radius + OSRM snap. It's faster and guaranteed to be on a real road.
+
+#### Location Modes on Entities
+
+Entities that have geographic positions declare how their coordinates are determined:
+
+```yaml
+entities:
+  kitchens:
+    fields: {kitchen_id: string, name: string, lat: double, lon: double, address: string}
+    location_mode: fixed              # coordinates provided in seed data
+
+  customers:
+    fields: {customer_id: string, lat: double, lon: double, address: string}
+    location_mode: generated_in_area
+    location_area:
+      center: ref(kitchens.lat, kitchens.lon)
+      radius_km: 6.4
+      reverse_geocode: true          # Nominatim → address string
+      # Uses RoadGraph.random_node() when road routing — no snap needed
+```
+
+- **`fixed`**: Coordinates are part of the seed data (airports, warehouses, offices)
+- **`generated_in_area`**: Random point within radius, optionally snapped to road and reverse-geocoded
+
+#### Tracking Events in the Blueprint
+
+```yaml
+tracking_events:
+  - name: driver_ping
+    during: [driver_picked_up->delivered]
+    interval_seconds: 60
+    route:
+      mode: road                     # road | air
+      waypoints:
+        - ref(events.order_created.body.kitchen_lat, kitchen_lon)
+        - ref(events.order_created.body.customer_lat, customer_lon)
+    body:
+      progress_pct: float
+      loc_lat: float                 # from route
+      loc_lon: float                 # from route
+
+  - name: flight_position
+    during: [departed->landed]
+    interval_seconds: 30
+    route:
+      mode: air
+      waypoints:
+        - ref(airports.origin.lat, lon)
+        - ref(airports.destination.lat, lon)
+    body:
+      progress_pct: float
+      lat: float                     # from route
+      lon: float                     # from route
+      altitude_ft:
+        profile: climb_cruise_descend
+        max: 35000
+      speed_knots:
+        profile: constant
+        value: 450
+        jitter: 20
+      heading: float                 # derived from route direction
+```
+
+#### Derived Field Profiles
+
+Some tracking body fields are computed from progress using built-in profiles:
+
+| Profile | Use case | Behavior |
+|---|---|---|
+| `climb_cruise_descend` | Aircraft altitude, train speed between stations | 0→max over climb phase, holds at max, max→0 over descent |
+| `constant` | Cruise speed, steady sensor readings | Fixed value with optional jitter |
+| `linear_ramp` | Fuel consumption, battery drain | Linear interpolation from start to end value |
+
+Custom profiles can be defined as Python functions in the body generators.
+
+#### How It Fits in the Canonical Generator
+
+1. **Context factory** computes the route once per entity lifecycle:
+   - Road mode: calls `osrm_route(waypoints)` → caches result
+   - Air mode: calls `great_circle_route(waypoints)`
+   - Stores `route_points` in context for tracking events to reference
+
+2. **Body generators** for tracking events use the route:
+   ```python
+   "driver_ping": lambda ctx, seed, rng, progress=0: {
+       "ping_lat": route_position_at(ctx["route_points"], progress)[0],
+       "ping_lon": route_position_at(ctx["route_points"], progress)[1],
+       "ping_progress": progress * 100,
+   }
+   ```
+
+3. **Derived fields** use profile functions:
+   ```python
+   "flight_position": lambda ctx, seed, rng, progress=0: {
+       "ping_lat": route_position_at(ctx["route_points"], progress)[0],
+       "ping_lon": route_position_at(ctx["route_points"], progress)[1],
+       "ping_altitude_ft": climb_cruise_descend(progress, max_value=35000),
+       "ping_speed_knots": constant_with_jitter(450, 20, rng),
+       "ping_heading": route_heading_at(ctx["route_points"], progress),
+   }
+   ```
+
+#### Worked Examples
+
+- **Ghost kitchen (road):** `assets/example_ghost_kitchen_transform.py` — OSRM routing, driver pings, customer location generation
+- **Airline (air):** `assets/example_airline_tracking.py` — great-circle routing, altitude/speed profiles, flight position tracking
+
 ---
 
 ## 3. Replay Engine
@@ -199,12 +335,43 @@ The replay engine is **business-agnostic** reusable code. It handles checkpointi
 
 **Code:** `assets/replay_engine.py` — ready to use, takes a `transform_fn` parameter.
 
+### Timeline Strategy: Instant History + Live Stream
+
+The key insight: **generate more data than you need, then start the cursor partway through.** This gives you instant historical data on first run, then live streaming going forward.
+
+```
+Dataset: 40 days of events (day 0 → day 39)
+Start day: 30
+
+First run (instant):
+  Day 0 ────────────────── Day 30 ── Day 30 + current time
+  │        HISTORICAL        │  ← all emitted instantly (no speed multiplier)
+  │     (~1 month of data)   │
+
+Subsequent runs (streaming):
+  Day 30 + current time ──────→ advancing at speed_multiplier × realtime
+  │  NEW EVENTS (live)       │
+```
+
+**Why this matters:**
+- Pipelines have data to process immediately (no waiting hours for volume)
+- Dashboards show trends and history from day 1
+- Agents have historical context for decisions
+- The demo looks "lived in" from the first minute
+
+**How to size it:**
+- `dataset_days`: How many total days to generate. 14 is minimal, 40 is comfortable.
+- `start_day`: Where to place the cursor. `dataset_days - 10` gives ~10 days of runway before looping.
+- `speed_multiplier`: How fast new events flow after backfill. 60 = 1 real minute covers 1 sim hour.
+
+These should be recorded in the Blueprint and passed to the replay job.
+
 ### How It Works
 
 **Inputs:**
 - Canonical dataset parquet with a `ts_seconds` column (the replay key)
 - A `transform_fn`: `(DataFrame, time_shift: int) -> DataFrame`
-- Config: catalog, schema, volume, start_day, speed_multiplier
+- Config: catalog, schema, volume, start_day, speed_multiplier, dataset_days
 - Optional: `entity_id_column` for loop-suffixing (e.g., `"order_id"`)
 
 **State (checkpoint files in volume):**
@@ -212,7 +379,7 @@ The replay engine is **business-agnostic** reusable code. It handles checkpointi
 - `_sim_start`: wall-clock time when simulation began (ISO timestamp)
 
 **Logic:**
-1. **First run**: backfill from day 0 → start_day + current time of day
+1. **First run**: backfill from day 0 → start_day + current time of day (all at once, fast)
 2. **Subsequent runs**: advance by `elapsed_real_time × speed_multiplier`
 3. **Looping**: wrap at dataset end, keep virtual timestamps monotonic, suffix entity IDs
 4. **Time-shift**: project events so they appear relative to "today"
@@ -265,3 +432,8 @@ After data generation, validate:
 - [ ] Demand volume looks realistic (not too uniform, not too sparse)
 - [ ] Seed data fields needed by downstream layers (pipeline, agent, app) are present
 - [ ] If documents exist: metadata JSON matches actual file contents
+- [ ] Entities with `location_mode: fixed` have lat/lon populated in seed data
+- [ ] Entities with `location_mode: generated_in_area` have a valid center reference and radius
+- [ ] Tracking events with `route` config have waypoint refs that resolve to valid coordinates
+- [ ] Route mode matches the business domain (road for ground, air for flights)
+- [ ] Derived field profiles produce realistic values (altitude > 0 during flight, etc.)

--- a/.agents/build-business/generate-data/assets/example_airline_tracking.py
+++ b/.agents/build-business/generate-data/assets/example_airline_tracking.py
@@ -1,0 +1,218 @@
+"""
+Worked Example: Airline flight tracking transform.
+
+This is the business-specific part that maps compact parquet columns
+to the output event JSON format for an airline business. Shows great-circle
+routing with altitude/speed profiles.
+
+Complements example_ghost_kitchen_transform.py which shows road-based routing.
+"""
+
+from pyspark.sql import DataFrame, functions as F
+import math
+
+# Airline event type mapping
+EVENT_TYPE_MAP = {
+    1: "booking_created",
+    2: "check_in",
+    3: "boarding",
+    4: "departed",
+    5: "flight_position",
+    6: "landed",
+    7: "completed",
+    8: "cancelled",
+    9: "diverted",
+}
+
+
+def airline_transform(df: DataFrame, time_shift: int) -> DataFrame:
+    """
+    Transform compact parquet columns into airline event format.
+
+    The canonical parquet has columns like:
+    - flight_id, origin_airport, destination_airport
+    - passenger_id, booking_class
+    - route_json: [[lat,lon], ...] from great-circle
+    - ping_lat, ping_lon, ping_progress (flight position updates)
+    - ping_altitude_ft, ping_speed_knots (derived from profiles)
+
+    Output: event_id, event_type, ts, flight_id, body (JSON string)
+    """
+
+    type_col = F.lit(None).cast("string")
+    for type_id, type_name in EVENT_TYPE_MAP.items():
+        type_col = F.when(F.col("event_type_id") == type_id, type_name).otherwise(type_col)
+
+    return (
+        df
+        .withColumn("event_type", type_col)
+
+        .withColumn(
+            "ts",
+            F.date_format(
+                F.from_unixtime(F.col("virtual_ts_seconds") + F.lit(time_shift)),
+                "yyyy-MM-dd HH:mm:ss.SSS",
+            ),
+        )
+
+        .withColumn(
+            "body",
+            F.when(
+                F.col("event_type") == "booking_created",
+                F.to_json(
+                    F.struct(
+                        F.col("passenger_id"),
+                        F.col("booking_class"),
+                        F.col("origin_airport").alias("origin"),
+                        F.col("destination_airport").alias("destination"),
+                        F.col("seat_assignment"),
+                    )
+                ),
+            )
+            .when(
+                F.col("event_type") == "departed",
+                F.to_json(
+                    F.struct(
+                        F.col("origin_airport").alias("origin"),
+                        F.col("destination_airport").alias("destination"),
+                        F.col("aircraft_type"),
+                        F.from_json(
+                            F.col("route_json"),
+                            "array<array<double>>",
+                        ).alias("route_points"),
+                    )
+                ),
+            )
+            .when(
+                F.col("event_type") == "flight_position",
+                F.to_json(
+                    F.struct(
+                        F.col("ping_progress").cast("double").alias("progress_pct"),
+                        F.col("ping_lat").cast("double").alias("lat"),
+                        F.col("ping_lon").cast("double").alias("lon"),
+                        F.col("ping_altitude_ft").cast("double").alias("altitude_ft"),
+                        F.col("ping_speed_knots").cast("double").alias("speed_knots"),
+                        F.col("ping_heading").cast("double").alias("heading"),
+                    )
+                ),
+            )
+            .when(
+                F.col("event_type") == "landed",
+                F.to_json(
+                    F.struct(
+                        F.col("destination_lat").cast("double").alias("lat"),
+                        F.col("destination_lon").cast("double").alias("lon"),
+                    )
+                ),
+            )
+            .when(
+                F.col("event_type") == "diverted",
+                F.to_json(
+                    F.struct(
+                        F.col("diversion_airport").alias("diversion_airport"),
+                        F.col("diversion_lat").cast("double").alias("lat"),
+                        F.col("diversion_lon").cast("double").alias("lon"),
+                        F.col("diversion_reason").alias("reason"),
+                    )
+                ),
+            )
+            .otherwise(F.lit("{}")),
+        )
+
+        .withColumn("event_id", F.expr("uuid()"))
+        .select("event_id", "event_type", "ts", "flight_id", "sequence", "body")
+    )
+
+
+# ── Canonical Generator Snippets ─────────────────────────────────────────────
+# These show how the canonical generator would compute tracking fields
+# for the airline business. Used as context_factory + body_generator examples.
+
+def airline_context_factory(seed_data, rng):
+    """Pick route, aircraft, passenger — everything for one flight."""
+    routes = seed_data["routes"]
+    airports = seed_data["airports"]
+    aircraft = seed_data["aircraft"]
+
+    # Pick a route
+    route = routes.sample(1, random_state=rng).iloc[0]
+    origin = airports[airports["iata"] == route["origin_iata"]].iloc[0]
+    destination = airports[airports["iata"] == route["destination_iata"]].iloc[0]
+
+    # Compute great-circle route
+    from routing import great_circle_route, great_circle_distance_km
+
+    waypoints = [(origin["lat"], origin["lon"]), (destination["lat"], destination["lon"])]
+    route_points = great_circle_route(waypoints, points_per_segment=100)
+    distance_km = great_circle_distance_km(waypoints[0], waypoints[1])
+
+    # Pick aircraft
+    plane = aircraft.sample(1, random_state=rng).iloc[0]
+
+    # Flight time based on distance (avg 800 km/h cruise)
+    flight_time_hours = distance_km / 800.0
+    flight_time_min = flight_time_hours * 60
+
+    return {
+        "ids": {
+            "flight_id": f"{route['airline_iata']}{rng.integers(100, 9999):04d}",
+        },
+        "origin": origin,
+        "destination": destination,
+        "route_points": route_points,
+        "distance_km": distance_km,
+        "flight_time_min": flight_time_min,
+        "aircraft": plane,
+        "route_json": [[p[0], p[1]] for p in route_points],
+    }
+
+
+def airline_body_generators():
+    """Body generators for each airline event type."""
+
+    from routing import (
+        route_position_at,
+        route_heading_at,
+        climb_cruise_descend,
+        constant_with_jitter,
+    )
+
+    return {
+        "booking_created": lambda ctx, seed, rng: {
+            "passenger_id": f"PAX-{rng.integers(10000, 99999)}",
+            "booking_class": rng.choice(["economy", "premium_economy", "business", "first"]),
+            "origin_airport": ctx["origin"]["iata"],
+            "destination_airport": ctx["destination"]["iata"],
+            "seat_assignment": f"{rng.integers(1, 40)}{rng.choice(list('ABCDEF'))}",
+        },
+        "check_in": lambda ctx, seed, rng: {},
+        "boarding": lambda ctx, seed, rng: {},
+        "departed": lambda ctx, seed, rng: {
+            "origin_airport": ctx["origin"]["iata"],
+            "destination_airport": ctx["destination"]["iata"],
+            "aircraft_type": ctx["aircraft"]["type"],
+            "route_json": json.dumps(ctx["route_json"]),
+        },
+        "flight_position": lambda ctx, seed, rng, progress=0: {
+            "ping_lat": route_position_at(ctx["route_points"], progress)[0],
+            "ping_lon": route_position_at(ctx["route_points"], progress)[1],
+            "ping_progress": progress * 100,
+            "ping_altitude_ft": climb_cruise_descend(progress, max_value=35000),
+            "ping_speed_knots": constant_with_jitter(450, 20, rng),
+            "ping_heading": route_heading_at(ctx["route_points"], progress),
+        },
+        "landed": lambda ctx, seed, rng: {
+            "destination_lat": ctx["destination"]["lat"],
+            "destination_lon": ctx["destination"]["lon"],
+        },
+        "completed": lambda ctx, seed, rng: {},
+        "cancelled": lambda ctx, seed, rng: {
+            "reason": rng.choice(["weather", "mechanical", "crew", "passenger_request"]),
+        },
+        "diverted": lambda ctx, seed, rng: {
+            "diversion_reason": rng.choice(["weather", "medical_emergency", "mechanical"]),
+        },
+    }
+
+
+import json  # needed by body_generators

--- a/.agents/build-business/generate-data/assets/example_ghost_kitchen_transform.py
+++ b/.agents/build-business/generate-data/assets/example_ghost_kitchen_transform.py
@@ -14,7 +14,7 @@ Usage:
         catalog="caspers",
         schema="simulator",
         volume="events",
-        start_day=70,
+        start_day=30,
         speed_multiplier=60.0,
         entity_id_column="order_id",
     )

--- a/.agents/build-business/generate-data/assets/replay_engine.py
+++ b/.agents/build-business/generate-data/assets/replay_engine.py
@@ -23,9 +23,9 @@ Usage:
         catalog="my_catalog",
         schema="simulator",
         volume="events",
-        start_day=70,
+        start_day=30,
         speed_multiplier=60.0,
-        dataset_days=90,
+        dataset_days=40,
         dataset_epoch_date=(2024, 1, 1),  # year, month, day the dataset starts
         entity_id_column="order_id",       # column to suffix on loops for uniqueness
     )
@@ -43,9 +43,9 @@ def replay(
     catalog: str,
     schema: str,
     volume: str,
-    start_day: int = 70,
+    start_day: int = 30,
     speed_multiplier: float = 60.0,
-    dataset_days: int = 90,
+    dataset_days: int = 40,
     dataset_epoch_date: Tuple[int, int, int] = (2024, 1, 1),
     entity_id_column: Optional[str] = None,
 ):

--- a/.agents/build-business/generate-data/assets/routing.py
+++ b/.agents/build-business/generate-data/assets/routing.py
@@ -1,0 +1,480 @@
+"""
+Routing Reference Implementation
+
+Provides real road routes (OSM graph + Dijkstra), great-circle routes (air),
+address resolution (Nominatim), and derived field profiles for tracking events.
+
+This is reference code for the LLM to draw on when generating canonical dataset
+generators. It should be inlined into generated code, not imported at runtime.
+
+Primary road routing: osmnx graph load + networkx Dijkstra (fast, local)
+Fallback road routing: OSRM public API (no install, but slow)
+Air routing: great-circle interpolation (pure math, zero deps)
+
+Dependencies for road routing: osmnx, networkx (pip install osmnx networkx)
+Dependencies for air routing: none (math only)
+Dependencies for address resolution: requests
+"""
+
+import math
+import time
+import json
+import hashlib
+import pickle
+from pathlib import Path
+from typing import List, Tuple, Optional, Dict, Any
+
+# ── Types ────────────────────────────────────────────────────────────────────
+
+Coordinate = Tuple[float, float]  # (lat, lon)
+Route = List[Coordinate]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OSM Graph Road Routing (PRIMARY — fast, local Dijkstra)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class RoadGraph:
+    """
+    Loads an OSM road network for an area and computes routes via Dijkstra.
+
+    Usage:
+        graph = RoadGraph.load(center=(37.77, -122.42), radius_km=6.4)
+        route, distance = graph.route(origin, destination)
+        route, distance = graph.route_multi([A, B, C, D])  # multi-stop
+        location = graph.random_node(rng)  # random routable point
+    """
+
+    def __init__(self, G, nodes_df, center_node):
+        self.G = G
+        self.nodes_df = nodes_df
+        self.center_node = center_node
+        self._route_cache: Dict[str, Tuple[Route, float]] = {}
+
+    @classmethod
+    def load(
+        cls,
+        center: Coordinate,
+        radius_km: float = 6.4,
+        network_type: str = "drive",
+        cache_dir: Optional[str] = None,
+    ) -> "RoadGraph":
+        """
+        Load an OSM road network centered on a point.
+
+        Args:
+            center: (lat, lon) center of the area
+            radius_km: Radius in kilometers to download
+            network_type: "drive" for car roads, "walk" for pedestrian paths,
+                          "bike" for cycling, "all" for everything
+            cache_dir: Directory to cache the graph pickle. None = no caching.
+
+        Returns:
+            RoadGraph instance ready for routing.
+        """
+        import osmnx as ox
+        import networkx as nx
+        import pandas as pd
+
+        cache_file = None
+        if cache_dir:
+            safe_name = f"{center[0]:.4f}_{center[1]:.4f}_{radius_km}_{network_type}"
+            cache_file = Path(cache_dir) / f"graph_{safe_name}.pkl"
+            if cache_file.exists():
+                print(f"Loading cached graph: {cache_file}")
+                with open(cache_file, "rb") as f:
+                    G = pickle.load(f)
+                center_node = ox.distance.nearest_nodes(G, center[1], center[0])
+                nodes_df = cls._extract_nodes(G, center_node, nx)
+                return cls(G, nodes_df, center_node)
+
+        print(f"Downloading OSM road network: center={center}, radius={radius_km}km, type={network_type}")
+        ox.settings.log_console = False
+        radius_m = radius_km * 1000
+        G = ox.graph_from_point(center, dist=radius_m, network_type=network_type)
+        print(f"Graph loaded: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
+
+        if cache_file:
+            cache_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(cache_file, "wb") as f:
+                pickle.dump(G, f)
+            print(f"Cached graph: {cache_file}")
+
+        center_node = ox.distance.nearest_nodes(G, center[1], center[0])
+        nodes_df = cls._extract_nodes(G, center_node, nx)
+
+        return cls(G, nodes_df, center_node)
+
+    @staticmethod
+    def _extract_nodes(G, center_node, nx) -> "pd.DataFrame":
+        """Extract all routable nodes in the connected component containing center."""
+        import pandas as pd
+
+        comp_map = {
+            n: cid
+            for cid, comp in enumerate(nx.connected_components(G.to_undirected()))
+            for n in comp
+        }
+        center_comp = comp_map.get(center_node)
+
+        nodes = []
+        for node_id, data in G.nodes(data=True):
+            if comp_map.get(node_id) == center_comp:
+                nodes.append({
+                    "node_id": node_id,
+                    "lat": data["y"],
+                    "lon": data["x"],
+                })
+        return pd.DataFrame(nodes)
+
+    def nearest_node(self, lat: float, lon: float) -> int:
+        """Find the nearest graph node to a coordinate."""
+        import osmnx as ox
+        return ox.distance.nearest_nodes(self.G, lon, lat)
+
+    def random_node(self, rng) -> Dict[str, Any]:
+        """
+        Pick a random routable node from the graph.
+
+        Returns:
+            {"node_id": int, "lat": float, "lon": float}
+        """
+        row = self.nodes_df.sample(1, random_state=rng).iloc[0]
+        return {"node_id": int(row["node_id"]), "lat": row["lat"], "lon": row["lon"]}
+
+    def route(
+        self, origin: Coordinate, destination: Coordinate
+    ) -> Tuple[Route, float]:
+        """
+        Compute shortest path between two points via Dijkstra.
+
+        Args:
+            origin: (lat, lon)
+            destination: (lat, lon)
+
+        Returns:
+            (route_points, distance_meters)
+        """
+        return self.route_multi([origin, destination])
+
+    def route_multi(self, waypoints: List[Coordinate]) -> Tuple[Route, float]:
+        """
+        Compute road route through multiple waypoints (multi-stop).
+
+        Chains shortest paths between consecutive waypoints.
+
+        Args:
+            waypoints: List of (lat, lon) tuples. Minimum 2.
+
+        Returns:
+            (route_points, total_distance_meters)
+        """
+        import networkx as nx
+
+        cache_key = json.dumps([(round(w[0], 6), round(w[1], 6)) for w in waypoints])
+        if cache_key in self._route_cache:
+            return self._route_cache[cache_key]
+
+        all_coords = []
+        total_dist = 0.0
+
+        for i in range(len(waypoints) - 1):
+            origin_node = self.nearest_node(waypoints[i][0], waypoints[i][1])
+            dest_node = self.nearest_node(waypoints[i + 1][0], waypoints[i + 1][1])
+
+            try:
+                path = nx.shortest_path(self.G, origin_node, dest_node, weight="length")
+            except nx.NetworkXNoPath:
+                # Fall back to undirected
+                path = nx.shortest_path(
+                    self.G.to_undirected(), origin_node, dest_node, weight="length"
+                )
+
+            coords = [(self.G.nodes[n]["y"], self.G.nodes[n]["x"]) for n in path]
+            dist = sum(
+                min(d["length"] for d in self.G[u][v].values())
+                for u, v in zip(path[:-1], path[1:])
+            )
+
+            # Avoid duplicating junction points
+            if i > 0 and all_coords:
+                coords = coords[1:]
+
+            all_coords.extend(coords)
+            total_dist += dist
+
+        result = (all_coords, total_dist)
+        self._route_cache[cache_key] = result
+        return result
+
+    def generate_location_in_area(
+        self,
+        rng,
+        center: Optional[Coordinate] = None,
+        with_address: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Generate a random location by picking a graph node.
+
+        Much better than random-point-in-radius because the point is guaranteed
+        to be on a real road. No OSRM snap needed.
+
+        Args:
+            rng: numpy random generator
+            center: ignored (uses graph's built-in node set)
+            with_address: if True, reverse geocode via Nominatim
+
+        Returns:
+            {"node_id": int, "lat": float, "lon": float, "address": str or None}
+        """
+        node = self.random_node(rng)
+        address = None
+        if with_address:
+            try:
+                address = reverse_geocode(node["lat"], node["lon"])
+            except Exception:
+                address = f"{node['lat']:.6f}, {node['lon']:.6f}"
+        node["address"] = address
+        return node
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OSRM Road Routing (FALLBACK — no install needed, but slow per-call)
+# ══════════════════════════════════════════════════════════════════════════════
+
+import requests
+
+OSRM_BASE = "https://router.project-osrm.org"
+
+_osrm_route_cache: Dict[str, Route] = {}
+
+
+def osrm_route(waypoints: List[Coordinate], retries: int = 3) -> Tuple[Route, float]:
+    """
+    Compute a road route through ordered waypoints via OSRM public API.
+
+    Slower than RoadGraph (one HTTP call per route), but zero install dependencies.
+    Use as fallback when osmnx is not available.
+
+    Args:
+        waypoints: List of (lat, lon) tuples. Minimum 2.
+        retries: Number of retry attempts on failure.
+
+    Returns:
+        (route_points, total_distance_meters)
+    """
+    raw = json.dumps(waypoints, sort_keys=True)
+    key = hashlib.md5(raw.encode()).hexdigest()
+    if key in _osrm_route_cache:
+        return _osrm_route_cache[key], 0.0
+
+    # OSRM expects lon,lat (not lat,lon)
+    coords_str = ";".join(f"{lon},{lat}" for lat, lon in waypoints)
+    url = f"{OSRM_BASE}/route/v1/driving/{coords_str}"
+    params = {"overview": "full", "geometries": "geojson"}
+
+    for attempt in range(retries):
+        try:
+            resp = requests.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+
+            if data.get("code") != "Ok":
+                raise ValueError(f"OSRM error: {data.get('code')} - {data.get('message', '')}")
+
+            route = data["routes"][0]
+            coords = [(c[1], c[0]) for c in route["geometry"]["coordinates"]]
+            distance = route["distance"]
+
+            _osrm_route_cache[key] = coords
+            return coords, distance
+
+        except (requests.RequestException, ValueError) as e:
+            if attempt < retries - 1:
+                time.sleep(1 * (attempt + 1))
+                continue
+            raise RuntimeError(f"OSRM routing failed after {retries} attempts: {e}")
+
+
+def osrm_nearest(lat: float, lon: float) -> Coordinate:
+    """Snap a coordinate to the nearest routable road point via OSRM."""
+    url = f"{OSRM_BASE}/nearest/v1/driving/{lon},{lat}"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+
+    if data.get("code") != "Ok" or not data.get("waypoints"):
+        raise ValueError(f"OSRM nearest failed: {data.get('code')}")
+
+    snapped = data["waypoints"][0]["location"]
+    return (snapped[1], snapped[0])
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Great-Circle (Air) Routing
+# ══════════════════════════════════════════════════════════════════════════════
+
+def great_circle_route(
+    waypoints: List[Coordinate],
+    points_per_segment: int = 50,
+) -> Route:
+    """
+    Interpolate a great-circle route through ordered waypoints.
+
+    Suitable for flights, drones, or any non-road movement.
+    """
+    route = []
+    for i in range(len(waypoints) - 1):
+        segment = _interpolate_great_circle(waypoints[i], waypoints[i + 1], points_per_segment)
+        if i > 0:
+            segment = segment[1:]
+        route.extend(segment)
+    return route
+
+
+def _interpolate_great_circle(
+    start: Coordinate, end: Coordinate, num_points: int
+) -> Route:
+    """Interpolate points along a great-circle arc between two coordinates."""
+    lat1, lon1 = math.radians(start[0]), math.radians(start[1])
+    lat2, lon2 = math.radians(end[0]), math.radians(end[1])
+
+    d = 2 * math.asin(
+        math.sqrt(
+            math.sin((lat2 - lat1) / 2) ** 2
+            + math.cos(lat1) * math.cos(lat2) * math.sin((lon2 - lon1) / 2) ** 2
+        )
+    )
+
+    if d < 1e-10:
+        return [start] * num_points
+
+    points = []
+    for i in range(num_points):
+        f = i / (num_points - 1) if num_points > 1 else 0
+        a = math.sin((1 - f) * d) / math.sin(d)
+        b = math.sin(f * d) / math.sin(d)
+        x = a * math.cos(lat1) * math.cos(lon1) + b * math.cos(lat2) * math.cos(lon2)
+        y = a * math.cos(lat1) * math.sin(lon1) + b * math.cos(lat2) * math.sin(lon2)
+        z = a * math.sin(lat1) + b * math.sin(lat2)
+        lat = math.degrees(math.atan2(z, math.sqrt(x**2 + y**2)))
+        lon = math.degrees(math.atan2(y, x))
+        points.append((lat, lon))
+
+    return points
+
+
+def great_circle_distance_km(start: Coordinate, end: Coordinate) -> float:
+    """Haversine distance in kilometers between two coordinates."""
+    R = 6371.0
+    lat1, lon1 = math.radians(start[0]), math.radians(start[1])
+    lat2, lon2 = math.radians(end[0]), math.radians(end[1])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    return R * 2 * math.asin(math.sqrt(a))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Address Resolution (Nominatim)
+# ══════════════════════════════════════════════════════════════════════════════
+
+NOMINATIM_BASE = "https://nominatim.openstreetmap.org"
+NOMINATIM_HEADERS = {"User-Agent": "caspers-data-generator/1.0"}
+
+
+def geocode(address: str) -> Coordinate:
+    """Forward geocode: address string → (lat, lon). Rate limited 1 req/sec."""
+    resp = requests.get(
+        f"{NOMINATIM_BASE}/search",
+        params={"q": address, "format": "json", "limit": 1},
+        headers=NOMINATIM_HEADERS,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    results = resp.json()
+    if not results:
+        raise ValueError(f"Geocoding failed: no results for '{address}'")
+    time.sleep(1)
+    return (float(results[0]["lat"]), float(results[0]["lon"]))
+
+
+def reverse_geocode(lat: float, lon: float) -> str:
+    """Reverse geocode: (lat, lon) → address string. Rate limited 1 req/sec."""
+    resp = requests.get(
+        f"{NOMINATIM_BASE}/reverse",
+        params={"lat": lat, "lon": lon, "format": "json"},
+        headers=NOMINATIM_HEADERS,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    time.sleep(1)
+    return data.get("display_name", f"{lat:.6f}, {lon:.6f}")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Route Position & Heading
+# ══════════════════════════════════════════════════════════════════════════════
+
+def route_position_at(route: Route, progress: float) -> Coordinate:
+    """Get (lat, lon) at a given progress (0.0 to 1.0) along a route."""
+    if not route:
+        raise ValueError("Empty route")
+    progress = max(0.0, min(1.0, progress))
+    idx = int(progress * (len(route) - 1))
+    return route[idx]
+
+
+def route_heading_at(route: Route, progress: float) -> float:
+    """Get heading (bearing, 0=north, 90=east) at a progress point along a route."""
+    if len(route) < 2:
+        return 0.0
+
+    progress = max(0.0, min(1.0, progress))
+    idx = int(progress * (len(route) - 1))
+    next_idx = min(idx + 1, len(route) - 1)
+
+    if idx == next_idx:
+        idx = max(0, idx - 1)
+
+    lat1, lon1 = math.radians(route[idx][0]), math.radians(route[idx][1])
+    lat2, lon2 = math.radians(route[next_idx][0]), math.radians(route[next_idx][1])
+
+    dlon = lon2 - lon1
+    x = math.sin(dlon) * math.cos(lat2)
+    y = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
+    bearing = math.degrees(math.atan2(x, y))
+    return (bearing + 360) % 360
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Derived Field Profiles
+# ══════════════════════════════════════════════════════════════════════════════
+
+def climb_cruise_descend(
+    progress: float,
+    max_value: float,
+    climb_end: float = 0.15,
+    descend_start: float = 0.85,
+) -> float:
+    """
+    Profile: climb, cruise, descend.
+    Common for: aircraft altitude, train speed between stations.
+    """
+    if progress <= climb_end:
+        return max_value * (progress / climb_end)
+    elif progress >= descend_start:
+        return max_value * (1.0 - (progress - descend_start) / (1.0 - descend_start))
+    else:
+        return max_value
+
+
+def constant_with_jitter(value: float, jitter: float, rng) -> float:
+    """Constant value with random noise. Common for: cruise speed, sensor readings."""
+    return value + rng.uniform(-jitter, jitter)
+
+
+def linear_ramp(progress: float, start_value: float, end_value: float) -> float:
+    """Linear interpolation. Common for: fuel consumption, battery drain."""
+    return start_value + (end_value - start_value) * progress

--- a/.agents/build-business/generate-data/skill.md
+++ b/.agents/build-business/generate-data/skill.md
@@ -91,6 +91,18 @@ Two files:
 
 The replay engine in `assets/replay_engine.py` is **reference material** for how the replay logic works. Generated code should inline it, not import from it.
 
+### Timeline Configuration
+
+The canonical generator and replay work together to create **instant historical data + live streaming**:
+
+- **`dataset_days`** (Blueprint → `timeline.dataset_days`): How many days to pre-generate. Default 40.
+- **`start_day`** (Blueprint → `timeline.start_day`): Where the replay cursor starts. Days before this = instant backfill on first run. Default `dataset_days - 10`.
+- **`speed_multiplier`** (Blueprint → `timeline.speed_multiplier`): How fast new events flow after backfill. 60 = 1 real minute covers 1 sim hour.
+
+The canonical generator accepts `--days=N`. The replay accepts `--start-day=N` and `--speed=X`.
+
+Read `assets/data-generation.md` section "Timeline Strategy" for the full explanation. **Always configure this in the Blueprint** — if the user doesn't specify, suggest `dataset_days: 40, start_day: 30, speed_multiplier: 60.0` as sensible defaults.
+
 ### Unstructured Documents
 - Files in `data/documents/` organized by type
 - Metadata JSON alongside each document set
@@ -99,7 +111,7 @@ The replay engine in `assets/replay_engine.py` is **reference material** for how
 ### Infrastructure
 - Volume declarations in `databricks.yml` for events, canonical, and misc
 - Job declarations for seed loader, canonical generator, and event replay (with schedule)
-- Schema declaration for `data` within the business catalog
+- Schema is created via SQL during catalog setup — do NOT declare it in `databricks.yml`
 
 ## Event Schema
 
@@ -139,6 +151,34 @@ When providing DBSQL queries for the user to test data:
 4. **Never reference columns like `entity_id` unless the generator actually produces that column.** The entity ID (batch_id, order_id, visit_id, etc.) is typically inside the body JSON, not a top-level column. Check what the replay transform actually outputs as top-level columns.
 5. **Validate every query against the Blueprint before presenting it.** For each column reference, trace it to either a top-level output column or a body field in the Blueprint.
 
+## Spatial Tracking
+
+When the Blueprint includes tracking events with a `route` config, generate spatial tracking code.
+
+Read `assets/data-generation.md` for the full spatial section and `assets/routing.py` for the reference implementation.
+
+### What to generate
+
+1. **In the canonical generator**: inline routing functions from `assets/routing.py` (don't import — inline the functions you need). The context factory should compute routes, and tracking body generators should use `route_position_at()`.
+
+2. **In the replay transform**: tracking events already have `ping_lat`, `ping_lon`, etc. as compact parquet columns. The transform just assembles them into the body JSON (same as non-spatial events).
+
+3. **For `generated_in_area` entities**: the canonical generator creates random locations (with optional road snap + reverse geocode) during context setup.
+
+### Route mode selection
+
+- Use `road` (OSRM) for ground vehicles: delivery, ride share, fleet, ambulance
+- Use `air` (great-circle) for aircraft, drones, ships (roughly), satellites
+- Multi-stop: just more waypoints in the list — both modes handle it
+
+### Dependencies
+
+Road routing: `osmnx`, `networkx` — install via `%pip install osmnx networkx` at the top of the canonical generator. The graph is loaded once, then all routes are local Dijkstra (milliseconds each).
+
+Air routing: no dependencies (pure math).
+
+Address resolution: `requests` for Nominatim geocoding. For road businesses, prefer `RoadGraph.random_node()` over Nominatim — it's faster and guaranteed routable.
+
 ## Coherence Rules
 
 You must validate after generation:
@@ -148,6 +188,10 @@ You must validate after generation:
 - Every `/Volumes/...` path in code has a matching volume in `databricks.yml`
 - All PK/FK constraints in seed generator match the entity relationships in the Blueprint
 - If documents exist: metadata matches file contents
+- Entities with `location_mode: fixed` have lat/lon in seed data
+- Entities with `location_mode: generated_in_area` have a valid center ref and radius
+- Tracking event waypoint refs resolve to real coordinates
+- Route mode matches the domain (road for ground, air for flight)
 
 ## What You Never Do
 
@@ -160,3 +204,6 @@ You must validate after generation:
 - Default the catalog to `main`
 - Use `get_json_field` in SQL queries
 - Reference non-existent columns in sample queries
+- Use OSRM API as primary routing — use `RoadGraph` (osmnx + Dijkstra) instead
+- Compute routes per-entity instead of loading the graph once at startup
+- Generate tracking events without a route when the Blueprint specifies spatial tracking

--- a/.agents/build-business/skill.md
+++ b/.agents/build-business/skill.md
@@ -60,7 +60,13 @@ Before generating any code, set up the catalog:
    ```
    Then create the `data` schema the same way: `CREATE SCHEMA {catalog}.data`
 5. **Find the warehouse ID** with `databricks warehouses list --profile {profile}` and record it in the Blueprint.
-6. **Confirm with the user** before proceeding.
+6. **Present the timeline defaults and ask the user to confirm or adjust:**
+
+> I'll generate **40 days** of historical data, with the replay starting at **day 30**. This gives you ~1 month of historical data available immediately on first run, with 10 days of runway before the dataset loops. New events stream at **60x speed** (1 real minute = 1 sim hour).
+>
+> Want to adjust any of these? (More/fewer days, different start point, faster/slower speed?)
+
+7. **Confirm everything with the user** before proceeding.
 
 All data goes in a schema called `data` within the chosen catalog:
 ```
@@ -71,7 +77,7 @@ All data goes in a schema called `data` within the chosen catalog:
 /Volumes/{catalog}/data/misc/
 ```
 
-Record the catalog name and profile in the Blueprint.
+Record the catalog name, profile, and timeline settings in the Blueprint.
 
 ### Phase 3: Generate Data
 Generate ONLY the data layer. Then deploy it.
@@ -128,6 +134,12 @@ status: elaborating  # seed | elaborating | generating | generated | deployed
 catalog: cascade_creek_brewing
 profile: CASPERSV2
 
+timeline:
+  dataset_days: 40          # how many days of events to pre-generate
+  start_day: 30             # replay cursor starts here (days 0-69 = instant history)
+  speed_multiplier: 60.0    # 1 real minute = 1 sim hour after backfill
+  replay_schedule: "*/5 * * * *"  # cron for replay job (every 5 min)
+
 entities:
   <name>:
     fields: {field: type, ...}
@@ -135,6 +147,12 @@ entities:
     foreign_keys:
       - {field: <field>, references: <entity>.<field>}
     count: <approximate rows in seed data>
+    location_mode: fixed | generated_in_area | null  # if entity has coordinates
+    location_area:                                    # only if generated_in_area
+      center: ref(<entity>.<lat_field>, <lon_field>)
+      radius_km: <number>
+      snap_to_road: true | false
+      reverse_geocode: true | false
     status: defined | generated
 
 events:
@@ -148,7 +166,17 @@ events:
     tracking_events:
       - name: <name>
         during: [<from>-><to>, ...]
-        body: {field: type, ...}
+        interval_seconds: <number>
+        route:                              # optional — only for spatial tracking
+          mode: road | air
+          waypoints:
+            - ref(<source of lat, lon>)
+            - ref(<source of lat, lon>)
+        body:
+          <field>: <type>
+          <field>:                           # derived field with profile
+            profile: climb_cruise_descend | constant | linear_ramp
+            <profile_params>
   status: defined | generated
 
 pipeline: null   # SDP — not yet defined
@@ -173,22 +201,32 @@ Run these after every Blueprint update AND after generating code.
    - Never use `get_json_field` — it does not exist in Spark SQL
    - Never reference columns like `entity_id` unless the generator actually produces them — check the Blueprint
 
+### Spatial Rules
+8. **Location Coordinates**: Entities with `location_mode: fixed` must have lat/lon fields in seed data
+9. **Generated Locations**: Entities with `location_mode: generated_in_area` must have a valid center reference that resolves to an entity with coordinates
+10. **Route Waypoints**: Every waypoint ref in tracking event `route.waypoints` must resolve to valid coordinates
+11. **Route Mode**: `road` for ground movement, `air` for flight — flag mismatches (e.g., road mode between airports 1000km apart)
+
 ### Soft Warnings (inform user)
-8. **Dangling Entities**: Entity defined but not referenced by any event
-9. **Unconsumed Tables**: Pipeline output not used by agent or app
-10. **Missing Layers**: Events defined but no pipeline; pipeline defined but no agent
-11. **Incomplete States**: Event state with no transitions and not marked terminal
+12. **Dangling Entities**: Entity defined but not referenced by any event
+13. **Unconsumed Tables**: Pipeline output not used by agent or app
+14. **Missing Layers**: Events defined but no pipeline; pipeline defined but no agent
+15. **Incomplete States**: Event state with no transitions and not marked terminal
 
 ## Sub-Skills
 
-Each layer has its own skill that can operate standalone or be orchestrated by `build-business`:
+Each layer has its own skill with reference implementations, recipes, and worked examples.
 
-| Skill | Purpose | Standalone use case |
+**The data layer is fully developed.** SDP, agent, and app layers can still be generated — the coherence engine guides the process and the LLM draws on its general knowledge — but they don't yet have curated patterns or reference code to draw on.
+
+| Skill | Purpose | Maturity |
 |---|---|---|
-| `generate-data` | Seed data, event streams, documents | "Add a new dataset to my existing business" |
-| *(more to come)* | SDP, agent, app | |
+| `generate-data` | Seed data, event streams, GPS routing, documents | **Full** — recipes, reference code, worked examples |
+| *(generate-sdp)* | Spark Declarative Pipeline (bronze/silver/gold) | Planned — LLM generates from Blueprint, no reference patterns yet |
+| *(generate-agent)* | AI agent with UC function tools | Planned — LLM generates from Blueprint, no reference patterns yet |
+| *(generate-app)* | UI + database app | Planned — LLM generates from Blueprint, no reference patterns yet |
 
-When generating a layer, delegate to the appropriate sub-skill with the current Blueprint. The sub-skill generates artifacts; you validate coherence across layers.
+When generating a layer, delegate to the appropriate sub-skill with the current Blueprint. The sub-skill generates artifacts; you validate coherence across layers. For layers without a sub-skill yet, generate directly using the Blueprint and coherence rules.
 
 ## Recipes
 
@@ -203,9 +241,14 @@ Never force a recipe. If the user wants something custom, help them build it and
 
 Everything is **DABs-native**. No stage notebooks for infrastructure orchestration. No imperative SDK calls to create resources. No state manager for cleanup.
 
-- `databricks.yml` declares all infrastructure (pipelines, jobs, endpoints, apps, schemas, volumes)
+- `databricks.yml` declares all infrastructure (pipelines, jobs, endpoints, apps, volumes)
 - Code files define behavior (transforms, agent logic, app code, data generation)
-- `databricks bundle deploy` creates everything. `databricks bundle destroy` tears it down.
+- `databricks bundle deploy` creates volumes and jobs. `databricks bundle destroy` tears those down.
+- **Cleanup is two steps:**
+  1. `databricks bundle destroy` — removes jobs, volumes, and workspace files
+  2. `DROP CATALOG {catalog} CASCADE` via SQL — removes the catalog, schema, tables, and all data
+
+  Always remind the user of both steps when they ask to clean up.
 
 Generated files:
 | File | Purpose |
@@ -237,6 +280,8 @@ The catalog IS the business. All data lives in a `data` schema within it:
 
 In `databricks.yml`, do NOT set a default catalog to `main` or any generic name. The catalog variable should default to the business-specific catalog name from the Blueprint.
 
+**Do NOT declare schemas in `databricks.yml`.** The catalog and schema are created via SQL during Phase 2.5. If `databricks.yml` also declares the schema as a resource, DABs will error with "Schema already exists" on deploy. Only declare volumes and jobs in `databricks.yml` — schemas are SQL-managed.
+
 ### Seed Data as Managed Delta Tables
 
 Seed data must be written as **managed Delta tables** (not parquet files in volumes). Use `spark.createDataFrame(df).write.saveAsTable()`. This enables:
@@ -264,6 +309,22 @@ All generated code must run on Databricks serverless. Follow these rules:
 4. **No `if __name__ == "__main__":` guard** — serverless doesn't invoke scripts as `__main__`. Call `main()` directly at module level.
 5. **Serverless jobs need `environments` block** — every job must declare an environment and every task must reference `environment_key`.
 
+### DABs Target Configuration
+
+**CRITICAL:** Always use `mode: production` on the default target. Without this, DABs prefixes resource names with `dev_{username}_`, which creates schemas like `dev_nick_karpov_data` instead of `data` — breaking volume paths and causing mismatches between SQL-created schemas and DABs-created volumes.
+
+```yaml
+targets:
+  default:
+    mode: production
+    default: true
+    workspace:
+      host: <workspace_url>
+      root_path: /Workspace/Users/<user_email>/.bundle/${bundle.name}/${bundle.target}
+```
+
+**`root_path` is required** when using `mode: production`. Use the current user's email (from `databricks auth profiles` or the Blueprint). Without it, DABs will error at deploy time.
+
 ### Serverless Job Template
 
 Every job in `databricks.yml` should follow this pattern:
@@ -275,7 +336,7 @@ jobs:
     environments:
       - environment_key: default
         spec:
-          client: "1"
+          environment_version: "5"
     tasks:
       - task_key: my_task
         environment_key: default
@@ -297,6 +358,9 @@ jobs:
 - Use `__file__`, `Path(__file__)`, or `if __name__ == "__main__":` in Databricks code
 - Write seed data to volumes as parquet (use managed Delta tables with PK/FK)
 - Forget volume declarations in `databricks.yml` for paths used in code
+- Use a `dev` target without `mode: production` — DABs will prefix resource names and break volume paths
+- Declare schemas in `databricks.yml` — they're created via SQL; declaring them in DABs causes "already exists" errors
+- Omit `root_path` from a `mode: production` target — DABs will reject the deploy
 - Default the catalog to `main` — always use the business-specific catalog
 - Modify AGENTS.md — it is static
 - Reference columns in queries that don't exist in the generated schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Caspers is a skill that builds fully deployable Databricks business demos from natural language. Describe a business — airline, bank, hospital, ghost kitchen — and Caspers generates coherent streaming data, Spark Declarative Pipelines, AI agents, and apps.
 
+**Current state:** The data generation layer is fully developed with recipes, reference implementations (real road routing via OSM, great-circle for air, address resolution), and worked examples. SDP, agent, and app layers can be generated using the coherence engine and LLM general knowledge, but don't have curated patterns yet.
+
 ## How It Works
 
 This repo is both the tool and the output. Clone it, talk to your AI coding agent, and the repo becomes your business.

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1,5 +1,0 @@
-# Business Blueprint
-
-This file is maintained by the build-business skill. It tracks all decisions about the business being built and validates coherence across layers.
-
-**Status:** No business defined yet. Run `/build-business` to start.

--- a/README.md
+++ b/README.md
@@ -25,16 +25,18 @@ The repo starts as a skeleton and becomes your business.
 
 ## What Gets Generated
 
-| File | Purpose |
-|---|---|
-| `BLUEPRINT.md` | Living business blueprint — tracks all decisions |
-| `databricks.yml` | DABs infrastructure declaration |
-| `data/seed_generator.py` | Managed Delta tables with PK/FK constraints |
-| `data/canonical_generator.py` | State machine event dataset |
-| `data/replay.py` | Streaming replay engine |
-| `pipelines/transforms.py` | SDP bronze → silver → gold |
-| `agents/agent.py` | MLflow agent definition |
-| `apps/app/` | FastAPI + frontend |
+| File | Purpose | Maturity |
+|---|---|---|
+| `BLUEPRINT.md` | Living business blueprint — tracks all decisions | Core |
+| `databricks.yml` | DABs infrastructure declaration | Core |
+| `data/seed_generator.py` | Managed Delta tables with PK/FK constraints | Full |
+| `data/canonical_generator.py` | State machine event dataset with GPS routing | Full |
+| `data/replay.py` | Streaming replay engine | Full |
+| `pipelines/transforms.py` | SDP bronze → silver → gold | Planned |
+| `agents/agent.py` | MLflow agent definition | Planned |
+| `apps/app/` | FastAPI + frontend | Planned |
+
+**Full** = curated patterns, reference code, worked examples. **Planned** = the skill generates these using the blueprint and LLM general knowledge, but no specialized recipes yet.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Add real GPS routing to the data generation skill: OSM graph + Dijkstra for road, great-circle for air
- Restructure generate-data as nested sub-skill under build-business
- Fix DABs configuration issues found during testing (mode: production, root_path, schema conflicts, environment_version)
- Add timeline strategy (40 days default, 30 days history on first run)

## What's new
- **routing.py** — reference implementation with `RoadGraph` class (osmnx + Dijkstra), OSRM fallback, great-circle, Nominatim geocoding, derived field profiles
- **example_airline_tracking.py** — worked example for air routing with altitude/speed
- **Spatial section in data-generation.md** — routing primitive, location modes, Blueprint syntax, address resolution
- **Timeline strategy** — diagram and explanation of instant history + live streaming pattern

## DABs fixes
- `mode: production` + `root_path` required (prevents `dev_` prefix on resources)
- Schemas created via SQL only, not in databricks.yml (avoids "already exists" errors)
- `environment_version: "5"` replaces deprecated `client` field
- Two-step cleanup documented (bundle destroy + DROP CATALOG CASCADE)

## Tested with
- SF bike courier (road routing, multi-stop, Portland OSM graph — 41K GPS pings)
- Elliott Bay harbor tours (great-circle water routing — 82K events, 4 boats)

This pull request was AI-assisted by Isaac.